### PR TITLE
記事検索とデータ取得ロジックの実装

### DIFF
--- a/apps/backend/prisma/migrations/20251223061612_articles/migration.sql
+++ b/apps/backend/prisma/migrations/20251223061612_articles/migration.sql
@@ -1,0 +1,22 @@
+-- CreateTable
+CREATE TABLE `articles` (
+    `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    `handle` VARCHAR(50) NOT NULL,
+    `author_id` BIGINT UNSIGNED NOT NULL,
+    `title` VARCHAR(255) NOT NULL,
+    `content_md` TEXT NOT NULL,
+    `content_html` TEXT NOT NULL,
+    `likes_count` INTEGER UNSIGNED NOT NULL DEFAULT 0,
+    `bookmarks_count` INTEGER UNSIGNED NOT NULL DEFAULT 0,
+    `views_count` INTEGER UNSIGNED NOT NULL DEFAULT 0,
+    `status` ENUM('draft', 'published', 'archived') NOT NULL DEFAULT 'draft',
+    `published_at` DATETIME(3) NULL,
+    `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updated_at` DATETIME(3) NOT NULL,
+
+    UNIQUE INDEX `articles_handle_key`(`handle`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `articles` ADD CONSTRAINT `articles_author_id_fkey` FOREIGN KEY (`author_id`) REFERENCES `users`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -55,6 +55,8 @@ model User {
 
   // リレーション
   sessions         UserSession[]
+  //▼12-23追記：ユーザーが書いた記事とのリレーション
+  articles         Article[]
 
   @@map("users") // 実テーブル名
 }
@@ -92,4 +94,39 @@ model UserSession {
   user         User      @relation(fields: [userId], references: [id])
 
   @@map("user_sessions")
+}
+//▼12-23追記：記事ステータスのEnum定義
+enum ArticleStatus {
+  draft
+  published
+  archived
+}
+//▼12-23追記：記事モデルの定義
+model Article {
+  // BigInt + Unsigned なので @db.UnsignedBigInt
+  id             BigInt        @id @default(autoincrement()) @db.UnsignedBigInt
+  
+  handle         String        @unique @db.VarChar(50)
+  
+  authorId       BigInt        @map("author_id") //@db.UnsignedBigInt
+  user             User        @relation(fields: [authorId], references: [id], onDelete: Cascade)
+
+  title          String        @db.VarChar(255)
+
+  // 【重要】プログラムでは contentMd, DBでは content_md
+  contentMd      String        @map("content_md") @db.Text
+  contentHtml    String        @map("content_html") @db.Text
+
+  likesCount     Int           @default(0) @map("likes_count") @db.UnsignedInt
+  bookmarksCount Int           @default(0) @map("bookmarks_count") @db.UnsignedInt
+  viewsCount     Int           @default(0) @map("views_count") @db.UnsignedInt
+
+  status         ArticleStatus @default(draft)
+  
+  publishedAt    DateTime?     @map("published_at") 
+
+  createdAt      DateTime      @default(now()) @map("created_at")
+  updatedAt      DateTime      @updatedAt @map("updated_at")
+
+  @@map("articles")
 }

--- a/apps/backend/src/controllers/artSerch1Controller.ts
+++ b/apps/backend/src/controllers/artSerch1Controller.ts
@@ -1,0 +1,23 @@
+import { Request, Response, NextFunction } from 'express';
+import { articleService } from '../services/artSerch1Service';
+
+export const searchArticlesController = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  try {
+    // クエリパラメータの受け取り
+    const keyword = (req.query.q as string) || '';
+    const page = Number(req.query.page) || 1;
+    const limit = Number(req.query.limit) || 10;
+
+    // Service実行
+    const result = await articleService.searchArticles(keyword, page, limit);
+
+    // レスポンス返却
+    res.status(200).json(result);
+  } catch (e) {
+    next(e);
+  }
+};

--- a/apps/backend/src/repositories/artSerch1Repository.ts
+++ b/apps/backend/src/repositories/artSerch1Repository.ts
@@ -1,0 +1,43 @@
+import { PrismaClient, Prisma, ArticleStatus } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export const articleRepository = {
+  /**
+   * キーワード検索 (公開済みの記事のみを対象とする例)
+   */
+  async findManyByKeyword(keyword: string, skip: number, take: number) {
+    // 検索条件: 公開済み(published) かつ (タイトル OR 本文にキーワードが含まれる)
+    const whereCondition: Prisma.ArticleWhereInput = {
+      status: ArticleStatus.published, // 公開済みのみ
+      AND: keyword
+        ? {
+            OR: [
+              { title: { contains: keyword } },
+              { contentMd: { contains: keyword } }, // 本文(Markdown)を検索
+            ],
+          }
+        : {},
+    };
+
+    // トランザクションで一覧と総数を取得
+    const [articles, totalCount] = await prisma.article.findMany{
+        where: whereCondition,
+        skip: skip,
+        take: take,
+        orderBy: { publishedAt: 'desc' }, // 公開日順
+        include: {
+          author: {
+            select: {
+              name: true,
+              handle: true,
+              avatarUrl: true,
+            },
+          },
+        },
+      }),
+    };
+
+    return { articles, totalCount };
+  },
+};

--- a/apps/backend/src/repositories/artSerch2Repository.ts
+++ b/apps/backend/src/repositories/artSerch2Repository.ts
@@ -1,132 +1,103 @@
-// 型定義
-// データベースにある「記事テーブル（articles）」の型
+import { prisma } from '../lib/prisma'; 
+import { Prisma } from '@prisma/client';
+
+// --- 型定義 ---
+
+// フロントエンドに返す記事データの型
 export interface Article {
-    id: number;
-    title: string;
-    content: string;
-    status: 'draft' | 'published' | 'archived';
-    createdAt: Date;
-    updatedAt: Date;
+  id: number;           // JSで扱いやすいようにnumberに変換します
+  handle: string;
+  authorId: number;     // JSで扱いやすいようにnumberに変換します
+  title: string;
+  contentMd: string;
+  contentHtml: string;
+  likesCount: number;
+  bookmarksCount: number; // ★スキーマに合わせて追加
+  viewsCount: number;     // ★スキーマに合わせて追加
+  status: 'draft' | 'published' | 'archived';
+  publishedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;        // ★スキーマに合わせて追加
 }
 
-// serviceから渡された「検索条件」の型定義
+// 検索条件の型
 export type ArtSearch2RepositoryParams = {
-    offset: number; // 取得開始位置
-    limit: number; // 1ページあたりの件数
-    keywords: string[]; // 検索キーワードの配列
-    status: 'published'; // 固定値 'published'
+  offset: number;
+  limit: number;
+  keywords: string[];
+  status: 'published';
 };
 
-// repositoryが返す「検索結果」の型
-// 記事のリストだけではなく、ページネーション用に「総件数」も含めて返す。
+// 戻り値の型
 export type SearchResult = {
-    articles: Article[]; // 記事の配列
-    totalCount: number; // 検索結果の総件数
+  articles: Article[];
+  totalCount: number;
 };
 
-// Repositoryの設計図（インターフェース）
-// 「このクラスは find メソッドを必ず持っています」という約束事
+// インターフェース
 export interface IArticleRepository {
-    find(params: ArtSearch2RepositoryParams): Promise<SearchResult>;
+  find(params: ArtSearch2RepositoryParams): Promise<SearchResult>;
 }
 
-// MySQL用のクラスの実装
+// --- クラス実装 (Prisma版) ---
 
-// MySQLを使って記事データを取得・収集するクラス
-export class MySQLArticleRepository implements IArticleRepository {
+export class PrismaArticleRepository implements IArticleRepository {
+  
+  async find(params: ArtSearch2RepositoryParams): Promise<SearchResult> {
+    
+    // 1. 検索条件（WHERE句）の作成
+    const whereConditions: Prisma.ArticleWhereInput = {
+      status: 'published',
+    };
 
-    /**
-     * 【メイン処理】
-     * 検索条件を受け取り、データ取得と件数カウントを行うメソッド
-     */
-    async find(params: ArtSearch2RepositoryParams): Promise<SearchResult> {
-        
-        // ---------------------------------------------------------
-        // ステップA: 共通の条件文（WHERE句）を作る
-        // ---------------------------------------------------------
-        // データ取得用とカウント用で「同じ条件」を使うため、
-        // 下に作ったヘルパー関数(buildWhereClause)で先にSQLの部品を作ります。
-        // DRY原則（同じコードを二度書かない）の実践です。
-        const { whereSql, values } = this.buildWhereClause(params);
-
-        // ---------------------------------------------------------
-        // ステップB: データ取得用のSQLを組み立てる
-        // ---------------------------------------------------------
-        // SELECT * ... でデータを取ってきます。
-        // LIMIT と OFFSET を使って、特定のページの分だけ切り取ります。
-        const dataSql = `
-            SELECT * FROM articles 
-            ${whereSql} 
-            ORDER BY published_at DESC 
-            LIMIT ? OFFSET ?
-        `;
-
-        // SQLの「?」に入れる値を合体させます。
-        // [...values] は「さっき作った条件用の値リスト」を展開したもの。
-        // その後ろに、LIMITとOFFSETの値を追加します。
-        const dataValues = [...values, params.limit, params.offset];
-
-        // ---------------------------------------------------------
-        // ステップC: 総件数カウント用のSQLを組み立てる
-        // ---------------------------------------------------------
-        // SELECT COUNT(*) ... で「何件あるか」の数字だけ取ってきます。
-        // ここには LIMIT や OFFSET はつけません（全件数えたいから）。
-        const countSql = `
-            SELECT COUNT(*) as total FROM articles 
-            ${whereSql}
-        `;
-        //  これ以降はなぜかprasmaがうまく働かないのでダミーを入れています。
-        // ごめんなさい
-        // カウント用は LIMIT 等の値がいらないので、共通の values をそのまま使います。
-        const countValues = values;
-        
-// --- ログで完成したSQLを確認（学習用） ---
-        console.log("--- [1] データ取得クエリ ---");
-        console.log("SQL:", dataSql); 
-        console.log("パラメータ:", dataValues);
-
-        console.log("--- [2] カウント取得クエリ ---");
-        console.log("SQL:", countSql);
-        console.log("パラメータ:", countValues);
-
-        // ※本来はここで `await connection.execute(...)` を行います。
-        // 今回はダミーデータを返して終了します。
-        return {
-            articles: [], // 本当はここにDBから取れたデータが入ります
-            totalCount: 0 // 本当はここに countSql の結果が入ります
-        };
+    // キーワード検索（タイトル OR 本文）
+    if (params.keywords.length > 0) {
+      whereConditions.AND = params.keywords.map((word) => ({
+        OR: [
+          { title: { contains: word } },
+          { contentMd: { contains: word } } // スキーマの @map("content_md") はPrismaが自動で処理してくれます
+        ],
+      }));
     }
 
-    /**
-     * 【ヘルパー関数】by AI
-     * 検索条件から「WHERE句」と「埋め込む値」を生成する裏方さん。
-     * private なのでクラスの外からは見えません。
-     */
-    private buildWhereClause(params: ArtSearch2RepositoryParams) {
-        
-        // 1. ベースとなる条件
-        // 画像の要件: status = 'published' (公開済み) の記事のみ対象
-        let whereSql = "WHERE status = 'published'";
-        
-        // 2. パラメータを入れる箱
-        // SQLインジェクション対策のため、値は直接SQLに書かず、ここに入れます。
-        const values: any[] = [];
+    try {
+      // 2. データ取得とカウントを実行
+      const [totalCount, prismaArticles] = await prisma.$transaction([
+        prisma.articles.count({ where: whereConditions }),
+        prisma.articles.findMany({
+          where: whereConditions,
+          take: params.limit,
+          skip: params.offset,
+          orderBy: { publishedAt: 'desc' },
+        }),
+      ]);
 
-        // 3. キーワードごとのループ処理（AND検索）
-        // 画像の要件: スペース区切りで入力された際、すべてのワードを含む記事をヒットさせる
-        for (const word of params.keywords) {
-            
-            // SQLを継ぎ足していく
-            // (title LIKE ? OR content_md LIKE ?) という塊を追加します。
-            whereSql += " AND (title LIKE ? OR content_md LIKE ?)";
+      // 3. 型変換 (PrismaのBigInt → number)
+      // schema.prismaで id BigInt となっているため、変換しないとJSON送信時にクラッシュします
+      const formattedArticles: Article[] = prismaArticles.map((a:any) => ({
+        id: Number(a.id),
+        handle: a.handle,
+        authorId: Number(a.authorId),
+        title: a.title,
+        contentMd: a.contentMd,
+        contentHtml: a.contentHtml,
+        likesCount: a.likesCount,
+        bookmarksCount: a.bookmarksCount, // ★追加
+        viewsCount: a.viewsCount,         // ★追加
+        status: a.status as 'draft' | 'published' | 'archived',
+        publishedAt: a.publishedAt,
+        createdAt: a.createdAt,
+        updatedAt: a.updatedAt            // ★追加
+      }));
 
-            // 「?」に入る値を配列に追加
-            // % はワイルドカード（部分一致）です。
-            // タイトル用と本文用の2つ分 push します。
-            values.push(`%${word}%`, `%${word}%`);
-        }
+      return {
+        articles: formattedArticles,
+        totalCount: totalCount,
+      };
 
-        // 作成した「SQLの切れ端」と「値のリスト」をセットで返します
-        return { whereSql, values };
+    } catch (error) {
+      console.error('Prisma Error:', error);
+      return { articles: [], totalCount: 0 };
     }
+  }
 }

--- a/apps/backend/src/repositories/artSerch2Repository.ts
+++ b/apps/backend/src/repositories/artSerch2Repository.ts
@@ -1,0 +1,132 @@
+// 型定義
+// データベースにある「記事テーブル（articles）」の型
+export interface Article {
+    id: number;
+    title: string;
+    content: string;
+    status: 'draft' | 'published' | 'archived';
+    createdAt: Date;
+    updatedAt: Date;
+}
+
+// serviceから渡された「検索条件」の型定義
+export type ArtSearch2RepositoryParams = {
+    offset: number; // 取得開始位置
+    limit: number; // 1ページあたりの件数
+    keywords: string[]; // 検索キーワードの配列
+    status: 'published'; // 固定値 'published'
+};
+
+// repositoryが返す「検索結果」の型
+// 記事のリストだけではなく、ページネーション用に「総件数」も含めて返す。
+export type SearchResult = {
+    articles: Article[]; // 記事の配列
+    totalCount: number; // 検索結果の総件数
+};
+
+// Repositoryの設計図（インターフェース）
+// 「このクラスは find メソッドを必ず持っています」という約束事
+export interface IArticleRepository {
+    find(params: ArtSearch2RepositoryParams): Promise<SearchResult>;
+}
+
+// MySQL用のクラスの実装
+
+// MySQLを使って記事データを取得・収集するクラス
+export class MySQLArticleRepository implements IArticleRepository {
+
+    /**
+     * 【メイン処理】
+     * 検索条件を受け取り、データ取得と件数カウントを行うメソッド
+     */
+    async find(params: ArtSearch2RepositoryParams): Promise<SearchResult> {
+        
+        // ---------------------------------------------------------
+        // ステップA: 共通の条件文（WHERE句）を作る
+        // ---------------------------------------------------------
+        // データ取得用とカウント用で「同じ条件」を使うため、
+        // 下に作ったヘルパー関数(buildWhereClause)で先にSQLの部品を作ります。
+        // DRY原則（同じコードを二度書かない）の実践です。
+        const { whereSql, values } = this.buildWhereClause(params);
+
+        // ---------------------------------------------------------
+        // ステップB: データ取得用のSQLを組み立てる
+        // ---------------------------------------------------------
+        // SELECT * ... でデータを取ってきます。
+        // LIMIT と OFFSET を使って、特定のページの分だけ切り取ります。
+        const dataSql = `
+            SELECT * FROM articles 
+            ${whereSql} 
+            ORDER BY published_at DESC 
+            LIMIT ? OFFSET ?
+        `;
+
+        // SQLの「?」に入れる値を合体させます。
+        // [...values] は「さっき作った条件用の値リスト」を展開したもの。
+        // その後ろに、LIMITとOFFSETの値を追加します。
+        const dataValues = [...values, params.limit, params.offset];
+
+        // ---------------------------------------------------------
+        // ステップC: 総件数カウント用のSQLを組み立てる
+        // ---------------------------------------------------------
+        // SELECT COUNT(*) ... で「何件あるか」の数字だけ取ってきます。
+        // ここには LIMIT や OFFSET はつけません（全件数えたいから）。
+        const countSql = `
+            SELECT COUNT(*) as total FROM articles 
+            ${whereSql}
+        `;
+        //  これ以降はなぜかprasmaがうまく働かないのでダミーを入れています。
+        // ごめんなさい
+        // カウント用は LIMIT 等の値がいらないので、共通の values をそのまま使います。
+        const countValues = values;
+        
+// --- ログで完成したSQLを確認（学習用） ---
+        console.log("--- [1] データ取得クエリ ---");
+        console.log("SQL:", dataSql); 
+        console.log("パラメータ:", dataValues);
+
+        console.log("--- [2] カウント取得クエリ ---");
+        console.log("SQL:", countSql);
+        console.log("パラメータ:", countValues);
+
+        // ※本来はここで `await connection.execute(...)` を行います。
+        // 今回はダミーデータを返して終了します。
+        return {
+            articles: [], // 本当はここにDBから取れたデータが入ります
+            totalCount: 0 // 本当はここに countSql の結果が入ります
+        };
+    }
+
+    /**
+     * 【ヘルパー関数】by AI
+     * 検索条件から「WHERE句」と「埋め込む値」を生成する裏方さん。
+     * private なのでクラスの外からは見えません。
+     */
+    private buildWhereClause(params: ArtSearch2RepositoryParams) {
+        
+        // 1. ベースとなる条件
+        // 画像の要件: status = 'published' (公開済み) の記事のみ対象
+        let whereSql = "WHERE status = 'published'";
+        
+        // 2. パラメータを入れる箱
+        // SQLインジェクション対策のため、値は直接SQLに書かず、ここに入れます。
+        const values: any[] = [];
+
+        // 3. キーワードごとのループ処理（AND検索）
+        // 画像の要件: スペース区切りで入力された際、すべてのワードを含む記事をヒットさせる
+        for (const word of params.keywords) {
+            
+            // SQLを継ぎ足していく
+            // (title LIKE ? OR content_md LIKE ?) という塊を追加します。
+            whereSql += " AND (title LIKE ? OR content_md LIKE ?)";
+
+            // 「?」に入る値を配列に追加
+            // % はワイルドカード（部分一致）です。
+            // タイトル用と本文用の2つ分 push します。
+            values.push(`%${word}%`, `%${word}%`);
+        }
+
+        // 作成した「SQLの切れ端」と「値のリスト」をセットで返します
+        return { whereSql, values };
+    }
+}

--- a/apps/backend/src/services/artSerch1Service.ts
+++ b/apps/backend/src/services/artSerch1Service.ts
@@ -1,0 +1,29 @@
+import { articleRepository } from '../repositories/artSerch1Repository';
+
+// BigInt対策 & 整形
+const serialize = (article: any) => ({
+  id: article.id.toString(),
+  handle: article.handle,
+  title: article.title,
+  // 検索結果用に本文(Markdown)の先頭100文字を抜粋
+  summary: article.contentMd.substring(0, 100) + '...', 
+  likesCount: article.likesCount,
+  viewsCount: article.viewsCount,
+  publishedAt: article.publishedAt,
+  author: {
+    name: article.author.name,
+    handle: article.author.handle,
+    avatarUrl: article.author.avatarUrl
+  }
+});
+
+export const articleService = {
+  async searchArticles(q: string, page: number, limit: number) {
+    const skip = (page - 1) * limit;
+    const { articles, totalCount } = await articleRepository.findManyByKeyword(q, skip, limit);
+    return {
+      articles: articles.map(serialize),
+      meta: { totalCount, currentPage: page, totalPages: Math.ceil(totalCount / limit) }
+    };
+  }
+};

--- a/apps/backend/src/services/artSerch2Service.ts
+++ b/apps/backend/src/services/artSerch2Service.ts
@@ -1,102 +1,64 @@
-// step0----- ArtSerch2Service用のユーティリティ関数群 -----
+// ファイル名に合わせてインポートパスを確認してください
+import { 
+    PrismaArticleRepository, 
+    SearchResult,
+    ArtSearch2RepositoryParams 
+} from '../repositories/artSerch2Repository';
 
-//controllerから渡される「検索条件」の型定義
+// Controllerから渡される「検索条件」の型定義
 export type ArtSearch2Params = {
-    page: number; // ページ番号
-    limit: number; // 1ページあたりの件数
-    keyword?: string; // 検索キーワード（省略可能）
-};
-//repository(データベース系)に渡す「検索条件」の型定義
-// serviceが計算した結果をここに詰めて渡す
-export type ArtSearch2RepositoryParams = {
-    offset: number; // 取得開始位置
-    limit: number; // 1ページあたりの件数
-    keywords: string[]; // 検索キーワードの配列
-    status: 'published'; // 固定値 'published'
+    page: number;
+    limit: number;
+    keyword?: string;
 };
 
-//------serviceクラスの実装-------
-/**
- * 記事検索のビジネスロジックを担当するクラスです。
- * データの計算や加工を行い、データベース係（Repository）に指示を出します。
- */
-class ArticleService {
+// ------ Serviceクラスの実装 -------
+
+export class ArticleService {
     
-    // クラスの中で使う関数（メソッド）を定義します。
-    // async (非同期) とは: 「DBへのアクセスは時間がかかるから、終わるのを待ってね」という印です。
-    // Promise<...> は将来的に返ってくるデータの型を表します。
-    async search(options: ArtSearch2Params): Promise<ArtSearch2RepositoryParams> {
+    // Repositoryをクラスのプロパティとして定義
+    private articleRepository: PrismaArticleRepository;
+
+    constructor() {
+        // インスタンス化
+        this.articleRepository = new PrismaArticleRepository();
+    }
+
+    /**
+     * メインの検索メソッド
+     */
+    async search(options: ArtSearch2Params): Promise<SearchResult> {
         
-        // 1. キーワードの分解処理（ステップ3のロジック）
-        // クラス内の private メソッド（下で定義）を使います。
-        // this. は「このクラスの」という意味です。
+        // 1. キーワードの分解
         const words: string[] = this.parseSearchKeyword(options.keyword);
 
-        // 2. ページネーションの計算（ステップ2のロジック）
-        // limit と page を使って offset を算出します。
+        // 2. ページネーション計算
         const offset: number = this.calculateOffset(options.page, options.limit);
 
-        // 3. 検索条件の組み立て（画像の「実装内容」の核心）
-        // ここで、Repositoryに渡すための命令書を作ります。
+        // 3. Repository用の条件作成
         const params: ArtSearch2RepositoryParams = {
             limit: options.limit,
             offset: offset,
             keywords: words,
-            status: 'published' // 画像の要件: 公開済み(status = 'published')のみ対象
+            status: 'published'
         };
 
-        // 4. Repository（データベース係）を呼び出す
-        // ※本当はここでRepositoryに params を渡してデータを取ってきます。
-        // 今はまだRepositoryがないので、コンソールに「命令書」を表示して確認します。
-        console.log("データベースへの命令を作成しました:", params);
+        // 4. Repositoryを呼び出す
+        // ★修正ポイント: this.ArtSearch2Repository ではなく this.articleRepository を使います
+        const result = await this.articleRepository.find(params);
 
-        // ここで本来は検索結果を返します
-        return params;
+        return result;
     }
 
+    // --- プライベートメソッド ---
 
-//  step1----- ページネーションと件数取得----
-/*
-const 関数名　＝ (引数1: 型, 引数2: 型): 戻り値の型 => {
-    処理内容
-    return 戻り値
-}
-*/
-
-    private calculateOffset = (page: number,limit:number): number =>{
-        // バリデーションチェック
-        // 1ページ未満の場合は0を返す
-        if (page < 1){return 0;}
-        // オフセット計算
-        // (ページ番号 - 1) * 1ページあたりの件数
-        // 例: 2ページ目で1ページあたり10件の場合、(2 - 1) * 10 = 10
+    private calculateOffset(page: number, limit: number): number {
+        if (page < 1) { return 0; }
         return (page - 1) * limit;
     }
 
-// step2----- 検索キーワードの処理 -----
-/*
-ユーザーが入力した生の検索文字列を、単語ごとのリスト（配列）に変更する関数。
-    今回の引数は rawKeyword で、型は string または undefined（省略可能）。
-    戻り値の型は string の配列（string[]）です。
-これは「文字列の入ったリスト（配列）」という意味の型。
-*/ 
-    private parseSearchKeyword = (rawKeyword?: string): string[] => {
-        // もし検索ワードが空っぽ(undefined)なら、空っぽの配列[]を返す。
-        if (!rawKeyword) {return [];}
-
-        //　トリムと分解
-        // 流れ　
-        // "  C言語   ポインタ  " (入力)
-        //    ↓ .trim()
-        // "C言語   ポインタ" (前後の空白が消える)
-        //    ↓ .split(...)
-        // ["C言語", "ポインタ"] (間の空白で区切る)
-        /*const words = rawKeyword
-            .trim() // 文字列の前後の空白を取り除く
-            .split(/\s+/); // 空白文字（スペース、タブ、改行など）で分割して配列にする
-
-        return words.filter(word => word !== ""); //念のため 空文字を取り除く*/
-
+    private parseSearchKeyword(rawKeyword?: string): string[] {
+        if (!rawKeyword) { return []; }
         return rawKeyword.trim().split(/\s+/).filter(word => word !== "");
     }
 }

--- a/apps/backend/src/services/artSerch2Service.ts
+++ b/apps/backend/src/services/artSerch2Service.ts
@@ -1,0 +1,102 @@
+// step0----- ArtSerch2Service用のユーティリティ関数群 -----
+
+//controllerから渡される「検索条件」の型定義
+export type ArtSearch2Params = {
+    page: number; // ページ番号
+    limit: number; // 1ページあたりの件数
+    keyword?: string; // 検索キーワード（省略可能）
+};
+//repository(データベース系)に渡す「検索条件」の型定義
+// serviceが計算した結果をここに詰めて渡す
+export type ArtSearch2RepositoryParams = {
+    offset: number; // 取得開始位置
+    limit: number; // 1ページあたりの件数
+    keywords: string[]; // 検索キーワードの配列
+    status: 'published'; // 固定値 'published'
+};
+
+//------serviceクラスの実装-------
+/**
+ * 記事検索のビジネスロジックを担当するクラスです。
+ * データの計算や加工を行い、データベース係（Repository）に指示を出します。
+ */
+class ArticleService {
+    
+    // クラスの中で使う関数（メソッド）を定義します。
+    // async (非同期) とは: 「DBへのアクセスは時間がかかるから、終わるのを待ってね」という印です。
+    // Promise<...> は将来的に返ってくるデータの型を表します。
+    async search(options: ArtSearch2Params): Promise<ArtSearch2RepositoryParams> {
+        
+        // 1. キーワードの分解処理（ステップ3のロジック）
+        // クラス内の private メソッド（下で定義）を使います。
+        // this. は「このクラスの」という意味です。
+        const words: string[] = this.parseSearchKeyword(options.keyword);
+
+        // 2. ページネーションの計算（ステップ2のロジック）
+        // limit と page を使って offset を算出します。
+        const offset: number = this.calculateOffset(options.page, options.limit);
+
+        // 3. 検索条件の組み立て（画像の「実装内容」の核心）
+        // ここで、Repositoryに渡すための命令書を作ります。
+        const params: ArtSearch2RepositoryParams = {
+            limit: options.limit,
+            offset: offset,
+            keywords: words,
+            status: 'published' // 画像の要件: 公開済み(status = 'published')のみ対象
+        };
+
+        // 4. Repository（データベース係）を呼び出す
+        // ※本当はここでRepositoryに params を渡してデータを取ってきます。
+        // 今はまだRepositoryがないので、コンソールに「命令書」を表示して確認します。
+        console.log("データベースへの命令を作成しました:", params);
+
+        // ここで本来は検索結果を返します
+        return params;
+    }
+
+
+//  step1----- ページネーションと件数取得----
+/*
+const 関数名　＝ (引数1: 型, 引数2: 型): 戻り値の型 => {
+    処理内容
+    return 戻り値
+}
+*/
+
+    private calculateOffset = (page: number,limit:number): number =>{
+        // バリデーションチェック
+        // 1ページ未満の場合は0を返す
+        if (page < 1){return 0;}
+        // オフセット計算
+        // (ページ番号 - 1) * 1ページあたりの件数
+        // 例: 2ページ目で1ページあたり10件の場合、(2 - 1) * 10 = 10
+        return (page - 1) * limit;
+    }
+
+// step2----- 検索キーワードの処理 -----
+/*
+ユーザーが入力した生の検索文字列を、単語ごとのリスト（配列）に変更する関数。
+    今回の引数は rawKeyword で、型は string または undefined（省略可能）。
+    戻り値の型は string の配列（string[]）です。
+これは「文字列の入ったリスト（配列）」という意味の型。
+*/ 
+    private parseSearchKeyword = (rawKeyword?: string): string[] => {
+        // もし検索ワードが空っぽ(undefined)なら、空っぽの配列[]を返す。
+        if (!rawKeyword) {return [];}
+
+        //　トリムと分解
+        // 流れ　
+        // "  C言語   ポインタ  " (入力)
+        //    ↓ .trim()
+        // "C言語   ポインタ" (前後の空白が消える)
+        //    ↓ .split(...)
+        // ["C言語", "ポインタ"] (間の空白で区切る)
+        /*const words = rawKeyword
+            .trim() // 文字列の前後の空白を取り除く
+            .split(/\s+/); // 空白文字（スペース、タブ、改行など）で分割して配列にする
+
+        return words.filter(word => word !== ""); //念のため 空文字を取り除く*/
+
+        return rawKeyword.trim().split(/\s+/).filter(word => word !== "");
+    }
+}

--- a/apps/frontend/src/pages/artSerchPage.html
+++ b/apps/frontend/src/pages/artSerchPage.html
@@ -1,0 +1,334 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>GakuWa - 記事検索</title>
+    <style>
+        /* --- 共通設定 (GakuWaテーマ) --- */
+        :root {
+            --primary-blue: #4A90E2; /* GakuWaロゴに近い青 */
+            --bg-color: #F5F7FA;
+            --white: #FFFFFF;
+            --text-main: #333333;
+            --text-sub: #777777;
+            --border-color: #E1E4E8;
+        }
+
+        body {
+            font-family: 'Helvetica Neue', Arial, 'Hiragino Kaku Gothic ProN', sans-serif;
+            margin: 0;
+            background-color: var(--bg-color);
+            color: var(--text-main);
+        }
+
+        a { text-decoration: none; color: inherit; }
+
+        /* --- ヘッダー --- */
+        header {
+            background-color: var(--white);
+            border-bottom: 1px solid var(--border-color);
+            padding: 0 20px;
+            height: 60px;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            position: sticky;
+            top: 0;
+            z-index: 100;
+        }
+
+        .logo {
+            font-size: 24px;
+            font-weight: bold;
+            color: var(--primary-blue); /* ロゴ色 */
+        }
+
+        .nav-links {
+            display: flex;
+            gap: 20px;
+            font-size: 14px;
+        }
+
+        .user-icon-header {
+            width: 36px;
+            height: 36px;
+            border-radius: 50%;
+            background-color: #ccc;
+            overflow: hidden;
+        }
+        .user-icon-header img { width: 100%; height: 100%; object-fit: cover; }
+
+        /* --- メインレイアウト (3カラム) --- */
+        .container {
+            max-width: 1200px;
+            margin: 20px auto;
+            display: grid;
+            grid-template-columns: 200px 1fr 200px; /* 左サイド・メイン・右サイド */
+            gap: 20px;
+            padding: 0 10px;
+        }
+
+        /* サイドバー (手書きメモのAdd部分) */
+        .sidebar {
+            background-color: #E8E8E8; /* グレーのプレースホルダー */
+            height: 300px; /* 仮の高さ */
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: #888;
+            border-radius: 8px;
+        }
+
+        /* --- 検索エリア (メインカラム) --- */
+        .search-header {
+            background: var(--white);
+            padding: 20px;
+            border-radius: 8px 8px 0 0;
+            border-bottom: 1px solid var(--border-color);
+            text-align: center;
+        }
+
+        .search-title {
+            font-size: 1.2rem;
+            margin-bottom: 10px;
+        }
+
+        .search-input-wrapper {
+            display: flex;
+            max-width: 500px;
+            margin: 0 auto;
+            gap: 10px;
+        }
+
+        input[type="text"] {
+            flex: 1;
+            padding: 10px;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+            font-size: 16px;
+        }
+
+        button.search-btn {
+            background-color: var(--primary-blue);
+            color: white;
+            border: none;
+            padding: 10px 20px;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+
+        /* --- 記事リスト --- */
+        .article-list {
+            background: var(--white);
+            min-height: 400px;
+            border-radius: 0 0 8px 8px;
+            padding: 0;
+            margin: 0;
+            list-style: none;
+        }
+
+        /* カードデザイン (手書きメモ準拠) */
+        .article-card {
+            padding: 20px;
+            border-bottom: 1px solid var(--border-color);
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+            transition: background 0.2s;
+        }
+
+        .article-card:hover {
+            background-color: #fafafa;
+        }
+
+        /* ユーザー情報 (メモでは右上にアイコンがあるが、一般的には左上が多い。メモに合わせて調整) */
+        .card-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+        }
+
+        .author-info {
+            font-size: 0.9rem;
+            color: var(--text-sub);
+        }
+
+        .author-icon {
+            width: 40px;
+            height: 40px;
+            border-radius: 50%;
+            object-fit: cover;
+            border: 1px solid #eee;
+        }
+
+        .article-title {
+            font-size: 1.1rem;
+            font-weight: bold;
+            color: var(--text-main);
+            margin: 5px 0;
+        }
+
+        .article-summary {
+            font-size: 0.9rem;
+            color: var(--text-sub);
+            line-height: 1.5;
+        }
+
+        /* タグ (DBにないので仮デザイン) */
+        .tags {
+            display: flex;
+            gap: 8px;
+            margin-top: 5px;
+        }
+        .tag {
+            background-color: #f0f0f0;
+            padding: 2px 8px;
+            border-radius: 4px;
+            font-size: 0.8rem;
+            color: #555;
+            border: 1px solid #ddd;
+        }
+
+        /* アクション (いいね数など) */
+        .card-footer {
+            display: flex;
+            gap: 15px;
+            margin-top: 10px;
+            font-size: 0.9rem;
+            color: var(--text-sub);
+        }
+        
+        .stat-item {
+            display: flex;
+            align-items: center;
+            gap: 5px;
+        }
+
+        /* レスポンシブ対応 (スマホでサイドバーを消す) */
+        @media (max-width: 768px) {
+            .container {
+                grid-template-columns: 1fr;
+            }
+            .sidebar { display: none; }
+        }
+    </style>
+</head>
+<body>
+
+    <header>
+        <div class="logo">GakuWa</div>
+        <nav class="nav-links">
+            <a href="#">ホーム</a>
+            <a href="#">イベント</a>
+            <a href="#">ブログ作成</a>
+        </nav>
+        <div class="user-icon-header">
+            <img src="https://placehold.co/100x100/4A90E2/white?text=Me" alt="User">
+        </div>
+    </header>
+
+    <div class="container">
+        <aside class="sidebar">Add</aside>
+
+        <main>
+            <div class="search-header">
+                <div class="search-input-wrapper">
+                    <input type="text" id="searchInput" placeholder="キーワードを入力 (例: 初心者)">
+                    <button class="search-btn" id="searchBtn">検索</button>
+                </div>
+                <p id="resultMsg" style="margin-top:10px; font-size:0.9rem; color:#666;"></p>
+            </div>
+
+            <ul id="articleList" class="article-list">
+                <li style="padding:20px; text-align:center; color:#888;">検索してください</li>
+            </ul>
+            
+            <div id="pagination" style="text-align:center; padding:20px; display:none;">
+                <button id="prevBtn">前へ</button>
+                <span id="pageInfo" style="margin:0 10px;"></span>
+                <button id="nextBtn">次へ</button>
+            </div>
+        </main>
+
+        <aside class="sidebar">Add</aside>
+    </div>
+
+    <script>
+        const API_URL = '/api/articles/search'; // 環境に合わせて変更
+        
+        const searchInput = document.getElementById('searchInput');
+        const searchBtn = document.getElementById('searchBtn');
+        const articleList = document.getElementById('articleList');
+        const resultMsg = document.getElementById('resultMsg');
+
+        // 検索実行
+        async function executeSearch() {
+            const keyword = searchInput.value;
+            if(!keyword) return;
+
+            resultMsg.textContent = `「${keyword}」の検索結果`;
+            articleList.innerHTML = '<li style="padding:20px; text-align:center;">Loading...</li>';
+
+            try {
+                // APIリクエスト
+                const res = await fetch(`${API_URL}?q=${encodeURIComponent(keyword)}&limit=10`);
+                if(!res.ok) throw new Error('Network error');
+                const data = await res.json();
+
+                renderArticles(data.articles);
+            } catch (e) {
+                console.error(e);
+                articleList.innerHTML = '<li style="padding:20px; text-align:center; color:red;">エラーが発生しました</li>';
+            }
+        }
+
+        // 記事描画
+        function renderArticles(articles) {
+            if(articles.length === 0) {
+                articleList.innerHTML = '<li style="padding:20px; text-align:center;">記事が見つかりませんでした</li>';
+                return;
+            }
+
+            articleList.innerHTML = '';
+            articles.forEach(article => {
+                // 手書きメモのデザインを再現
+                const li = document.createElement('li');
+                li.className = 'article-card';
+                li.innerHTML = `
+                    <div class="card-header">
+                        <div class="author-info">
+                            <div>${escapeHtml(article.author.name)} (@${escapeHtml(article.author.handle)})</div>
+                            <div style="font-size:0.8rem; color:#aaa;">${new Date(article.publishedAt).toLocaleDateString()}</div>
+                        </div>
+                        <img src="${article.author.avatarUrl || 'https://placehold.co/40'}" class="author-icon" alt="icon">
+                    </div>
+                    
+                    <a href="/articles/${article.handle}" class="article-title">${escapeHtml(article.title)}</a>
+                    
+                    <div class="article-summary">${escapeHtml(article.summary)}</div>
+
+                    <div class="tags">
+                        <span class="tag">C言語</span>
+                        <span class="tag">初心者</span>
+                    </div>
+
+                    <div class="card-footer">
+                        <span class="stat-item">♡ ${article.likesCount}</span>
+                        <span class="stat-item">👍 0</span> <span class="stat-item">👀 ${article.viewsCount}</span>
+                    </div>
+                `;
+                articleList.appendChild(li);
+            });
+        }
+
+        function escapeHtml(str) {
+            if(!str) return '';
+            return str.replace(/[&<>"']/g, m => ({ '&':'&amp;', '<':'&lt;', '>':'&gt;', '"':'&quot;', "'":'&#39;' })[m]);
+        }
+
+        searchBtn.addEventListener('click', executeSearch);
+        searchInput.addEventListener('keypress', (e) => { if(e.key === 'Enter') executeSearch(); });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
これは、記事検索とデータ取得ロジックの実装＃issue２です。
prismaの変更がうまくいかず、artSerch2Repository.tsの中身にテストをするダミーを仕込んでいて、データ取得のロジックがうまく組み込めていません。
後日調整ののち、修正版をアップロードしようと思います。
対処法を知っている方がいればDiscodeのDMにお願いします。